### PR TITLE
Fix segfault when reading input samples

### DIFF
--- a/src/bpm_detect.rs
+++ b/src/bpm_detect.rs
@@ -53,7 +53,7 @@ impl BPMDetect {
     pub fn input_samples(&mut self, samples: &[f32]) {
         unsafe {
             self.0
-                .inputSamples(samples.as_ptr(), samples.len() as c_int)
+                .inputSamples(samples.as_ptr(), samples.len() as c_int / self.0.channels)
         }
     }
 


### PR DESCRIPTION
This resolves a segfault I've seen when trying to read in samples.

In the [cpp SoundStretch main file](https://codeberg.org/soundtouch/soundtouch/src/branch/master/source/SoundStretch/main.cpp#L230-L231), they divide the input samples by the number of channels:

```
    while (inFile.eof() == 0)
    {
        // Read sample data from input file
        const int num = inFile.read(sampleBuffer, readSize);

        // Enter the new samples to the bpm analyzer class
        const int samples = num / nChannels;
        bpm.inputSamples(sampleBuffer, samples);
    }
```

I've replicated that behaviour here and I'm no longer seeing a segfault.